### PR TITLE
DOM manipulation only when document ready

### DIFF
--- a/src/toggleForcePublicCheckbox.js
+++ b/src/toggleForcePublicCheckbox.js
@@ -4,9 +4,11 @@
 
 // Toggles the WooComm's Post Editor > Memberships > Force Post Public checkbox.
 export function toggleForcePublicCheckbox( checked ) {
-  const element = document.getElementById( "_wc_memberships_force_public" );
-  element.checked = checked;
-  toggleHideContentRestrictionsDiv( element );
+  window.onload = () => {
+    const element = document.getElementById( "_wc_memberships_force_public" );
+    element.checked = checked;
+    toggleHideContentRestrictionsDiv( element );
+  };
 };
 
 // Hides or shows WooComm's Post Editor > Memberships div when checkbox is toggled.


### PR DESCRIPTION
Vanilla JS code for element manipulation should only be executed when document is ready.

Without this, for some reason a user with role `editor` gets a broken Block Editor with an error message, while `administrator` users still see the panel in the Block Editor fine.