### PR TITLE
Using domReady lib, better logic support for non-admin role

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "@wordpress/block-editor": "^3.7.5",
     "@wordpress/compose": "^3.11.0",
     "@wordpress/data": "^4.14.1",
-    "@wordpress/dom-ready": "^2.9.0",
+    "@wordpress/dom-ready": "^2.10.0",
     "@wordpress/element": "^2.11.0",
     "@wordpress/i18n": "^3.9.0",
     "newspack-components": "^1.0.5",

--- a/src/document-settings/index.js
+++ b/src/document-settings/index.js
@@ -8,6 +8,7 @@ import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import { registerPlugin } from '@wordpress/plugins';
 import { ToggleControl, TextControl } from '@wordpress/components';
 import { Component } from '@wordpress/element';
+import domReady from '@wordpress/dom-ready';
 
 /**
  * Internal dependencies
@@ -41,7 +42,9 @@ class WooCommPostAutoArchiveSettingsPanel extends Component {
     };
     onMetaChange( metaPayload );
     if ( metaPayload.newspack_woocomm_post_auto_archive ) {
-      toggleForcePublicCheckbox( metaPayload.newspack_woocomm_post_auto_archive );
+        domReady( function() {
+          toggleForcePublicCheckbox( metaPayload.newspack_woocomm_post_auto_archive );
+        } );
     }
   }
 

--- a/src/toggleForcePublicCheckbox.js
+++ b/src/toggleForcePublicCheckbox.js
@@ -1,27 +1,27 @@
 //
 // Integrations with WooComm Memberships in Post Editor.
-//
-
 // Toggles the WooComm's Post Editor > Memberships > Force Post Public checkbox.
+// Because it works with an element by ID, it must be called when document/window is ready and not sooner.
+//
 export function toggleForcePublicCheckbox( checked ) {
-  window.onload = () => {
     const element = document.getElementById( "_wc_memberships_force_public" );
+
+    // There are WP User Roles which won't have this checkbox available/visible, in which case, don't attempt to use it.
+    if ( ! element ) {
+      return;
+    }
     element.checked = checked;
-    toggleHideContentRestrictionsDiv( element );
-  };
-};
 
-// Hides or shows WooComm's Post Editor > Memberships div when checkbox is toggled.
-// Based on woocommerce-memberships/assets/js/admin/wc-memberships-admin.min.js
-function toggleHideContentRestrictionsDiv( element ) {
-  const div_js_restrictions = element.closest("p.form-field").nextElementSibling;
-  if ( ! div_js_restrictions.classList.contains( 'js-restrictions' ) ) {
-    return;
-  }
+    // Hides or shows WooComm's Post Editor > Memberships div when checkbox is toggled,
+    // based on `woocommerce-memberships/assets/js/admin/wc-memberships-admin.min.js`.
+    const div_js_restrictions = element.closest("p.form-field").nextElementSibling;
+    if ( ! div_js_restrictions.classList.contains( 'js-restrictions' ) ) {
+      return;
+    }
 
-  if ( element.checked ) {
-    div_js_restrictions.classList.add( "hide" );
-  } else {
-    div_js_restrictions.classList.remove( "hide" );
-  }
+    if ( element.checked ) {
+      div_js_restrictions.classList.add( "hide" );
+    } else {
+      div_js_restrictions.classList.remove( "hide" );
+    }
 };


### PR DESCRIPTION
Changes:
- used `domReady` from `'@wordpress/dom-ready'`
- cleaned up the unused `remove_auto_archive_on_save_post` callable on `save_post` action -- this logic was already abandoned in a previous PR, I just forgot to clean it up then
- added to programmatically check and set the `set_content_public` on Post, if Auto-archive is used and if Post isn't already forced public. Explanation: if a User with a role smaller than `administrator` edits a Post, WooComm's internal credentials doesn't give them access to the WooComm's Membership meta-box at the bottom of the Post Editor in which the "force public" option/checkbox is located; and so if a non-admin user edits a Post, they won't be able to set this check by themselves, which is why we must do it programmatically for Auto-archive to work properly in that case.